### PR TITLE
x-linux-qt: add qt6-layer to LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,6 +16,7 @@ LAYERSERIES_COMPAT_x-linux-qt = "scarthgap"
 
 LAYERDEPENDS_x-linux-qt  = "stm-st-stm32mp"
 LAYERDEPENDS_x-linux-qt += "st-openstlinux"
+LAYERDEPENDS_x-linux-qt += "qt6-layer"
 
 # OpenSTLinux compatibility version
 ST_OSTL_COMPATIBILITY_VERSION_stm-st-stm32mp = "6.2"


### PR DESCRIPTION
The x-linux-qt layer relies on recipes/classes provided by meta-qt6, but this dependency was not declared in the layer configuration. This caused build errors when meta-qt6 was not already present in the layer list, since bitbake had no way of knowing it was required.

Add meta-qt6 to LAYERDEPENDS so the dependency is resolved automatically and the layer fails fast with a clear error if meta-qt6 is missing, instead of failing later during the build.